### PR TITLE
Fix DataRecordLogger parameter null value

### DIFF
--- a/src/PSStreamLogger/Cmdlets/InvokeCommandWithLoggingCmdlet.cs
+++ b/src/PSStreamLogger/Cmdlets/InvokeCommandWithLoggingCmdlet.cs
@@ -28,8 +28,6 @@ namespace PSStreamLoggerModule
 
         private bool disposed = false;
 
-        private string? scriptArgumentVariableName;
-
         private DataRecordLogger? dataRecordLogger;
 
         public void Dispose()
@@ -58,9 +56,6 @@ namespace PSStreamLoggerModule
         protected override void BeginProcessing()
         {
             PrepareLogging();
-
-            // Determine the variable name for script arguments (different for Windows PowerShell and PowerShell Core)
-            scriptArgumentVariableName = InvokeCommand.InvokeScript("if ($args[0]) { \"`$args\" } else { \"`$input\" }", new bool[] { true })[0].BaseObject.ToString();
         }
 
         protected override void EndProcessing()
@@ -70,7 +65,7 @@ namespace PSStreamLoggerModule
             {
                 exec = () =>
                 {
-                    return InvokeCommand.InvokeScript($"& {{ {ScriptBlock} {Environment.NewLine}}} *>&1 | PSStreamLogger\\Out-PSStreamLogger -DataRecordLogger {scriptArgumentVariableName}[0]", false, PipelineResultTypes.Output, new List<object>() { dataRecordLogger! });
+                    return InvokeCommand.InvokeScript($"& {{ {ScriptBlock} {Environment.NewLine}}} *>&1 | PSStreamLogger\\Out-PSStreamLogger -DataRecordLogger $input[0]", false, PipelineResultTypes.Output, new List<object>() { dataRecordLogger! });
                 };
             }
             else

--- a/src/PSStreamLogger/PSStreamLogger.csproj
+++ b/src/PSStreamLogger/PSStreamLogger.csproj
@@ -10,7 +10,7 @@
     <AssemblyName>PSStreamLogger</AssemblyName>
     <RootNamespace>PSStreamLoggerModule</RootNamespace>
     
-    <Version>0.6.0-preview</Version>
+    <Version>0.6.1-preview</Version>
     <Authors>romandres</Authors>
     <NeutralLanguage>en-US</NeutralLanguage>
   </PropertyGroup>

--- a/src/PSStreamLogger/PSStreamLogger.psd1
+++ b/src/PSStreamLogger/PSStreamLogger.psd1
@@ -4,7 +4,7 @@
 RootModule = 'PSStreamLogger.dll'
 
 # Version number of this module.
-ModuleVersion = '0.6.0'
+ModuleVersion = '0.6.1'
 
 # ID used to uniquely identify this module
 GUID = '18b6925b-0c8f-4a14-abfa-c90550c025d7'


### PR DESCRIPTION
Fix DataRecordLogger parameter null value issue in PowerShell 7 by using the correct PowerShell script parameter name.